### PR TITLE
Running search on OSG Connect

### DIFF
--- a/workflow/generate_workflow.sh
+++ b/workflow/generate_workflow.sh
@@ -206,7 +206,7 @@ if [ "x${NO_PLAN}" == "x" ] ; then
       --append-pegasus-property 'pegasus.transfer.bypass.input.staging=true' \
       --append-site-profile 'osgconnect:env|LAL_DATA_PATH:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/e02dab8c/share/lalsimulation' \
       --append-site-profile 'osgconnect:env|LIGO_DATAFIND_SERVER:sugwg-condor.phy.syr.edu:80' \
-      --append-site-profile 'osgconnect:condor|requirements:((GLIDEIN_site isnt undefined) && (GLIDEIN_site isnt "IIT") && (GLIDEIN_site isnt "UChicago") && (HAS_CVMFS_oasis_opensciencegrid_org is true) && (HAS_CVMFS_gwosc_osgstorage_org is true))' \
+      --append-site-profile 'osgconnect:condor|requirements:((GLIDEIN_site isnt "IIT") && (GLIDEIN_site isnt "UChicago"))' \
       --append-site-profile "osgconnect:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:${PYCBC_TAG}\"" \
       --local-dir /local-scratch/${USER}/workflows
   elif [ ${PLATFORM} == "orangegrid" ] ; then

--- a/workflow/generate_workflow.sh
+++ b/workflow/generate_workflow.sh
@@ -206,6 +206,7 @@ if [ "x${NO_PLAN}" == "x" ] ; then
       --append-pegasus-property 'pegasus.transfer.bypass.input.staging=true' \
       --append-site-profile 'osgconnect:env|LAL_DATA_PATH:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/e02dab8c/share/lalsimulation' \
       --append-site-profile 'osgconnect:env|LIGO_DATAFIND_SERVER:sugwg-condor.phy.syr.edu:80' \
+      --append-site-profile 'osgconnect:condor|requirements:((GLIDEIN_site isnt undefined) && (GLIDEIN_site isnt "IIT") && (GLIDEIN_site isnt "UChicago") && (HAS_CVMFS_oasis_opensciencegrid_org is true) && (HAS_CVMFS_gwosc_osgstorage_org is true))' \
       --append-site-profile "osgconnect:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:${PYCBC_TAG}\"" \
       --local-dir /local-scratch/${USER}/workflows
   elif [ ${PLATFORM} == "orangegrid" ] ; then


### PR DESCRIPTION
@Rebecca333 Is hitting some bad sites that we've already known won't let us run. This will make the OSGConnect runs trail out to an exceedingly long time. I recommend we just squash them in the site catalog.

This is a bug in running on OSG. Please let me know if this isn't quite the right syntax. I took it from earlier runs to get rid of these sites, but it was given as `osg:condor|requirements...` rather than `osgconnect:condor|requirements...`.