### PR TITLE
InitialRequestMemory is computed based on DAGNodeRetry that Pegasus sets for each job

### DIFF
--- a/workflow/configuration/executables_osgconnect.ini
+++ b/workflow/configuration/executables_osgconnect.ini
@@ -145,7 +145,9 @@ hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-calculate_psd]
-condor|+InitialRequestMemory = 2000
+; pycbc|start_memory=2000
+; condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, %(pycbc|start_memory), %(pycbc|start_memory)*DAGNodeRetry)
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 2000, 2000*DAGNodeRetry)
 condor|request_cpus = ${calculate_psd|cores}
 dagman|priority = 5000
 dagman|retry = 10
@@ -155,7 +157,7 @@ pycbc|installed = True
 
 [pegasus_profile-coinc]
 dagman|priority = 5000
-condor|+InitialRequestMemory = 3000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 3000, 3000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
@@ -167,14 +169,14 @@ pycbc|installed = True
 
 [pegasus_profile-distribute_background_bins]
 dagman|priority = 5000
-condor|+InitialRequestMemory = 6000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 6000, 6000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-fit_by_template]
 dagman|priority = 5000
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
@@ -191,7 +193,7 @@ hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-hdfinjfind]
-condor|+InitialRequestMemory = 5000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 5000, 5000*DAGNodeRetry)
 dagman|priority = 500
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
@@ -199,7 +201,7 @@ pycbc|installed = True
 
 [pegasus_profile-hdf_trigger_merge]
 dagman|priority = 5000
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
@@ -232,7 +234,7 @@ pycbc|installed = True
 
 [pegasus_profile-optimal_snr]
 condor|request_cpus = ${optimal_snr|cores}
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 dagman|priority = 5000
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
@@ -274,13 +276,13 @@ hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-plot_binnedhist]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-plot_coinc_snrchi]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
@@ -296,7 +298,7 @@ hints|execution.site = osgconnect
 pycbc|installed = true
 
 [pegasus_profile-plot_hist]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
@@ -322,13 +324,13 @@ hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-plot_singles]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-plot_snrchi]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
@@ -339,7 +341,7 @@ hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-plot_spectrum]
-condor|+InitialRequestMemory = 3000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 3000, 3000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
@@ -356,14 +358,14 @@ hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-statmap]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 dagman|priority = 500
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-statmap_inj]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 dagman|priority = 500
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
@@ -386,25 +388,25 @@ hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-page_snglinfo]
-condor|+InitialRequestMemory = 4000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 4000, 4000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-plot_trigger_timeseries]
-condor|+InitialRequestMemory = 8000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 8000, 8000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-single_template_plot]
-condor|+InitialRequestMemory = 3000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 3000, 3000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True
 
 [pegasus_profile-single_template]
-condor|+InitialRequestMemory = 3000
+condor|+InitialRequestMemory = ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 3000, 3000*DAGNodeRetry)
 pycbc|site = osgconnect
 hints|execution.site = osgconnect
 pycbc|installed = True


### PR DESCRIPTION
the request_memory attribute for LIGO jobs is set to compute based on initial memory and NumJobStarts that is incremented when a job goes on hold

request_memory = ifthenelse( (LastHoldReasonCode=!=34 && LastHoldReasonCode=!=26), InitialRequestMemory, int(1.5 * NumJobStarts * MemoryUsage) )

However, when a job fails and then a new retry is triggered in DAGMan the NumJobStarts starts again for zero.  As a result, on a large analysis the jobs keep on failing, and starts request memory again from InitialRequest memory set

For example:

When i run the workflow on analysis segment 1


The jobs keep getting held because of memory usage 

[vahi@login03 o1-analysis-1-v1_13_1-LOSC_16_V1-main_ID0000001.000]$ pwd
/local-scratch/vahi/workflows/pycbc-tmp.SR0d8juhMk/work/o1-analysis-1-v1_13_1-LOSC_16_V1-main_ID0000001.000

02/27/19 07:47:53   Node calculate_psd-PART0-H1_ID67_ID0018653, HTCondor ID 1786992, status STATUS_SUBMITTED
02/27/19 07:47:53   Node calculate_psd-PART4-H1_ID71_ID0018657, HTCondor ID 1800959, status STATUS_SUBMITTED
02/27/19 07:56:38 Currently monitoring 1 HTCondor log file(s)
02/27/19 07:56:38 Event: ULOG_JOB_HELD for HTCondor Node calculate_psd-PART0-H1_ID67_ID0018653 (1786992.0.0) {02/27/19 07:56:35}
02/27/19 07:56:38   Hold reason: Job in status 2 put on hold by SYSTEM_PERIODIC_HOLD due to memory usage 4368748.
02/27/19 07:56:38 Number of idle job procs: 1
02/27/19 07:56:38 DAG status: 2 (DAG_STATUS_NODE_FAILED)
--
02/27/19 08:21:45   Node calculate_psd-PART0-H1_ID67_ID0018653, HTCondor ID 1786992, status STATUS_SUBMITTED
02/27/19 08:21:45   Node calculate_psd-PART4-H1_ID71_ID0018657, HTCondor ID 1800959, status STATUS_SUBMITTED
02/27/19 08:28:00 Currently monitoring 1 HTCondor log file(s)
02/27/19 08:28:00 Event: ULOG_JOB_HELD for HTCondor Node calculate_psd-PART1-H1_ID68_ID0018654 (1803861.0.0) {02/27/19 08:27:59}
02/27/19 08:28:00   Hold reason: Job in status 2 put on hold by SYSTEM_PERIODIC_HOLD due to memory usage 5066696.
02/27/19 08:28:00 Number of idle job procs: 1
02/27/19 08:28:00 DAG status: 2 (DAG_STATUS_NODE_FAILED)
--
02/27/19 08:53:49   Node calculate_psd-PART0-H1_ID67_ID0018653, HTCondor ID 1786992, status STATUS_SUBMITTED
02/27/19 08:53:49   Node calculate_psd-PART4-H1_ID71_ID0018657, HTCondor ID 1829170, status STATUS_SUBMITTED
02/27/19 08:56:04 Currently monitoring 1 HTCondor log file(s)
02/27/19 08:56:04 Event: ULOG_JOB_HELD for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1829170.0.0) {02/27/19 08:56:01}
02/27/19 08:56:04   Hold reason: Job in status 2 put on hold by SYSTEM_PERIODIC_HOLD due to memory usage 2980516.


I am not sure if your periodic_release expression in the jobs is having the intended effect
[vahi@login03 o1-analysis-1-v1_13_1-LOSC_16_V1-main_ID0000001.000]$ grep periodic calculate_psd-PART4-H1_ID71_ID0018657.sub 
periodic_release = ((HoldReasonCode =?= 34) || (HoldReasonCode =?= 26))
periodic_remove = (JobStatus == 5) && ((CurrentTime - EnteredCurrentStatus) > 43200)



02/25/19 10:37:06 Event: ULOG_JOB_HELD for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1746395.0.0) {02/25/19 10:37:06}
02/25/19 10:37:16 Event: ULOG_JOB_RELEASED for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1746395.0.0) {02/25/19 10:37:16}
02/25/19 12:57:27 Event: ULOG_JOB_HELD for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1746395.0.0) {02/25/19 12:57:25}
02/25/19 12:57:42 Event: ULOG_JOB_RELEASED for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1746395.0.0) {02/25/19 12:57:38}
02/25/19 18:10:59 Event: ULOG_JOB_TERMINATED for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1746395.0.0) {02/25/19 18:10:58}
02/25/19 19:22:25 Event: ULOG_JOB_HELD for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1750834.0.0) {02/25/19 19:22:22}
02/25/19 19:23:05 Event: ULOG_JOB_RELEASED for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1750834.0.0) {02/25/19 19:23:02}
02/25/19 23:53:12 Event: ULOG_JOB_HELD for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1750834.0.0) {02/25/19 23:53:08}
02/25/19 23:53:42 Event: ULOG_JOB_RELEASED for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1750834.0.0) {02/25/19 23:53:40}
02/26/19 05:50:46 Event: ULOG_JOB_TERMINATED for HTCondor Node calculate_psd-PART4-H1_ID71_ID0018657 (1750834.0.0) {02/26/19 05:50:44}


If you look at above the job gets released from held state only twice, before the job gets terminated and dagman retry kicks in

Basically, we go from 2GB initial memory to about 4.xGB memory and then start over again

A potential fix for this is to have the InitialRequestMemory be computed based on DAGNodeRetry that Pegasus sets for the jobs in the DAG file


+InitialRequestMemory =ifthenelse(isundefined(DAGNodeRetry) || DAGNodeRetry == 0, 2000, 2000*DAGNodeRetry)

periodic_release = ((HoldReasonCode =?= 34) || (HoldReasonCode =?= 26))
periodic_remove = (JobStatus == 5) && ((CurrentTime - EnteredCurrentStatus) > 43200)

In the .dag file generated by Pegasus DAGNodeRetry is defined
grep calculate_psd-PART0-H1_ID67_ID0018653 *dag
JOB calculate_psd-PART0-H1_ID67_ID0018653 ./calculate_psd-PART0-H1_ID67_ID0018653.sub
...
VARS calculate_psd-PART0-H1_ID67_ID0018653 +DAGNodeRetry="$(RETRY)”

The above commit, changes the InitialRequestMemory to that expression in the ini file

